### PR TITLE
fix / add instruction for symlink on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ streamlit run main.py
 ```bash
 # replace `/path/to/hummingbot` with the actual path
 ln -s /path/to/hummingbot/data data
+
+# if you need to remove the symlink
+unlink data
 ```
 
 For more info about Streamlit installation, see the instructions located at https://docs.streamlit.io/library/get-started/installation.


### PR DESCRIPTION
Add instruction for users who wants to remove the symlink or accidentally use a different path.

![image](https://github.com/hummingbot/dashboard/assets/73840223/6b8c013c-3874-4d7f-95cb-526bfdb9eb49)
