### PR TITLE
Proposing a bit more conda

### DIFF
--- a/environment_conda.yml
+++ b/environment_conda.yml
@@ -1,25 +1,25 @@
 name: dashboard
 channels:
-  - conda-forge
+  - default
 dependencies:
-  - python=3.9
+  - python
+  - streamlit
+  - watchdog
+  - plotly
   - sqlalchemy
+  - statsmodels
+  - pyyaml
+  - jupyter
+  - pathlib
   - pip
   - pip:
-      - streamlit
-      - watchdog
-      - plotly
       - pycoingecko
       - glom
       - defillama
-      - statsmodels
       - pandas_ta
-      - pyyaml
       - commlib-py
-      - jupyter
       - optuna
       - optuna-dashboard
-      - pathlib
       - streamlit-ace
       - st-pages
       - streamlit-elements==0.1.*


### PR DESCRIPTION
Several packages are provided with conda `default` channel. A few users (including me in Codespaces) experienced the environment creation failing with `conda-forge` channel. This could have been temporary, but no error messages where provided, just a `Terminated` when conda tried to create the environment