### PR TITLE
Feat/strategy performance v0.10

### DIFF
--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -90,7 +90,7 @@ def show_strategy_summary(summary_df: pd.DataFrame):
                              )
     selected_rows = summary[summary.Explore]
     if len(selected_rows) > 0:
-        return selected_rows.drop('Explore', axis=1)
+        return selected_rows
     else:
         return None
 
@@ -250,6 +250,9 @@ if selected_db is not None:
         with table_tab:
             selection = show_strategy_summary(strategy_data.strategy_summary)
             if selection is not None:
+                if len(selection) > 1:
+                    st.warning("This version doesn't support multiple selections. Please try selecting only one.")
+                    st.stop()
                 selected_exchange = selection["Exchange"].values[0]
                 selected_trading_pair = selection["Trading Pair"].values[0]
         with chart_tab:

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -94,6 +94,7 @@ def show_strategy_summary(summary_df: pd.DataFrame):
     else:
         return None
 
+
 def summary_chart(df: pd.DataFrame):
     fig = px.bar(df, x="Trading Pair", y="Realized PnL", color="Exchange")
     fig.update_traces(width=min(1.0, 0.1 * len(strategy_data.strategy_summary)))
@@ -172,20 +173,20 @@ def intraday_performance(df: pd.DataFrame):
         return hr_str + suffix
 
     df["hour"] = df["timestamp"].dt.hour
-    profits = df[df["net_realized_pnl"] >= 0]
-    losses = df[df["net_realized_pnl"] < 0]
-    polar_profits = profits.groupby("hour")["net_realized_pnl"].sum().reset_index()
-    polar_losses = losses.groupby("hour")["net_realized_pnl"].sum().reset_index()
-    polar_losses["net_realized_pnl"] = abs(polar_losses["net_realized_pnl"])
+    profits = df[df["realized_pnl"] >= 0]
+    losses = df[df["realized_pnl"] < 0]
+    polar_profits = profits.groupby("hour")["realized_pnl"].sum().reset_index()
+    polar_losses = losses.groupby("hour")["realized_pnl"].sum().reset_index()
+    polar_losses["realized_pnl"] = abs(polar_losses["realized_pnl"])
     fig = go.Figure()
     fig.add_trace(go.Barpolar(
         name="Profits",
-        r=polar_profits["net_realized_pnl"],
+        r=polar_profits["realized_pnl"],
         theta=polar_profits["hour"] * 15,
         marker_color=BULLISH_COLOR))
     fig.add_trace(go.Barpolar(
         name="Losses",
-        r=polar_losses["net_realized_pnl"],
+        r=polar_losses["realized_pnl"],
         theta=polar_losses["hour"] * 15,
         marker_color=BEARISH_COLOR))
     fig.update_layout(
@@ -258,7 +259,7 @@ if selected_db is not None:
             st.info("💡 Choose a trading pair and start analyzing!")
         else:
             st.divider()
-            st.subheader("🔍 Examine Trading Pair")
+            st.subheader("🔍 Explore Trading Pair")
             if not any("Error" in value for key, value in selected_db.status.items() if key != "position_executor"):
                 date_array = pd.date_range(start=strategy_data.start_time, end=strategy_data.end_time, periods=60)
                 start_time, end_time = st.select_slider("Select a time range to analyze",
@@ -278,7 +279,7 @@ if selected_db is not None:
                             st.metric(label='Total Trades', value=strategy_data_filtered.total_orders)
                         with col3:
                             st.metric(label='Accuracy',
-                                      value=round(strategy_data_filtered.accuracy, 2))
+                                      value=f"{100 * strategy_data_filtered.accuracy:.2f} %")
                         with col4:
                             st.metric(label="Profit Factor",
                                       value=round(strategy_data_filtered.profit_factor, 2))
@@ -337,7 +338,7 @@ if selected_db is not None:
                                 st.plotly_chart(fig, use_container_width=True)
                             with col2:
                                 st.plotly_chart(intraday_performance(page_data_filtered.trade_fill), use_container_width=True)
-                                st.plotly_chart(top_n_trades(page_data_filtered.trade_fill.net_realized_pnl), use_container_width=True)
+                                st.plotly_chart(top_n_trades(page_data_filtered.trade_fill.realized_pnl), use_container_width=True)
                     else:
                         st.warning("Market data is not available so the candles graph is not going to be rendered. "
                                    "Make sure that you are using the latest version of Hummingbot and market data recorder activated.")

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -338,42 +338,41 @@ if selected_db is not None:
 
                     st.subheader("💱 Market activity")
                     if "Error" not in selected_db.status["market_data"] and strategy_data_filtered.market_data is not None:
-                        with st.expander("Market activity", expanded=True):
-                            col1, col2, col3 = st.columns([1, 1, 2])
-                            with col1:
-                                interval = st.selectbox("Candles Interval:", intervals.keys(), index=2)
-                            with col2:
-                                rows_per_page = st.number_input("Candles per Page", value=100, min_value=1, max_value=5000)
-                            with col3:
-                                total_rows = len(
-                                    strategy_data_filtered.get_market_data_resampled(interval=f"{intervals[interval]}S"))
-                                total_pages = math.ceil(total_rows / rows_per_page)
-                                if total_pages > 1:
-                                    selected_page = st.select_slider("Select page", list(range(total_pages)), total_pages - 1,
-                                                                     key="page_slider")
-                                else:
-                                    selected_page = 0
-                                start_idx = selected_page * rows_per_page
-                                end_idx = start_idx + rows_per_page
-                                candles_df = strategy_data_filtered.get_market_data_resampled(
-                                    interval=f"{intervals[interval]}S").iloc[
-                                             start_idx:end_idx]
-                                start_time_page = candles_df.index.min()
-                                end_time_page = candles_df.index.max()
-                                page_data_filtered = single_market_strategy_data.get_filtered_strategy_data(start_time_page,
-                                                                                                            end_time_page)
-                            col1, col2 = st.columns([5.5, 1.5])
-                            with col1:
-                                cg = CandlesGraph(candles_df, show_volume=False, extra_rows=2)
-                                cg.add_buy_trades(page_data_filtered.buys)
-                                cg.add_sell_trades(page_data_filtered.sells)
-                                cg.add_pnl(page_data_filtered, row=2)
-                                cg.add_quote_inventory_change(page_data_filtered, row=3)
-                                fig = cg.figure()
-                                st.plotly_chart(fig, use_container_width=True)
-                            with col2:
-                                st.plotly_chart(intraday_performance(page_data_filtered.trade_fill), use_container_width=True)
-                                st.plotly_chart(top_n_trades(page_data_filtered.trade_fill.realized_pnl), use_container_width=True)
+                        col1, col2, col3 = st.columns([1, 1, 2])
+                        with col1:
+                            interval = st.selectbox("Candles Interval:", intervals.keys(), index=2)
+                        with col2:
+                            rows_per_page = st.number_input("Candles per Page", value=1500, min_value=1, max_value=5000)
+                        with col3:
+                            total_rows = len(
+                                strategy_data_filtered.get_market_data_resampled(interval=f"{intervals[interval]}S"))
+                            total_pages = math.ceil(total_rows / rows_per_page)
+                            if total_pages > 1:
+                                selected_page = st.select_slider("Select page", list(range(total_pages)), total_pages - 1,
+                                                                 key="page_slider")
+                            else:
+                                selected_page = 0
+                            start_idx = selected_page * rows_per_page
+                            end_idx = start_idx + rows_per_page
+                            candles_df = strategy_data_filtered.get_market_data_resampled(
+                                interval=f"{intervals[interval]}S").iloc[
+                                         start_idx:end_idx]
+                            start_time_page = candles_df.index.min()
+                            end_time_page = candles_df.index.max()
+                            page_data_filtered = single_market_strategy_data.get_filtered_strategy_data(start_time_page,
+                                                                                                        end_time_page)
+                        col1, col2 = st.columns([5.5, 1.5])
+                        with col1:
+                            cg = CandlesGraph(candles_df, show_volume=False, extra_rows=2)
+                            cg.add_buy_trades(page_data_filtered.buys)
+                            cg.add_sell_trades(page_data_filtered.sells)
+                            cg.add_pnl(page_data_filtered, row=2)
+                            cg.add_quote_inventory_change(page_data_filtered, row=3)
+                            fig = cg.figure()
+                            st.plotly_chart(fig, use_container_width=True)
+                        with col2:
+                            st.plotly_chart(intraday_performance(page_data_filtered.trade_fill), use_container_width=True)
+                            st.plotly_chart(returns_histogram(page_data_filtered.trade_fill), use_container_width=True)
                     else:
                         st.warning("Market data is not available so the candles graph is not going to be rendered. "
                                    "Make sure that you are using the latest version of Hummingbot and market data recorder activated.")

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -238,7 +238,6 @@ def intraday_performance(df: pd.DataFrame):
 
 
 def returns_histogram(df: pd.DataFrame):
-    colors = [BULLISH_COLOR if val > 0 else BEARISH_COLOR for val in df["realized_pnl"]]
     fig = go.Figure()
     fig.add_trace(go.Histogram(name="Losses",
                                x=df.loc[df["realized_pnl"] < 0, "realized_pnl"],
@@ -246,16 +245,14 @@ def returns_histogram(df: pd.DataFrame):
     fig.add_trace(go.Histogram(name="Profits",
                                x=df.loc[df["realized_pnl"] > 0, "realized_pnl"],
                                marker_color=BULLISH_COLOR))
-    fig.update_layout(title=dict(
-                            text='Returns Histogram',
+    fig.update_layout(
+        title=dict(
+                            text='Returns Distribution',
                             x=0.5,
-                            # y=0.93,
                             xanchor="center",
-                            # yanchor="bottom"
                         ),
         legend=dict(
             orientation="h",
-            # entrywidth=70,
             yanchor="bottom",
             y=1.02,
             xanchor="center",

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -107,8 +107,17 @@ def pnl_over_time(df: pd.DataFrame):
     df_below = df[df['net_realized_pnl'] < 0]
 
     fig = go.Figure()
-    fig.add_trace(go.Bar(x=df_above.index, y=df_above["net_realized_pnl"], marker_color=BULLISH_COLOR, showlegend=False))
-    fig.add_trace(go.Bar(x=df_below.index, y=df_below["net_realized_pnl"], marker_color=BEARISH_COLOR, showlegend=False))
+    fig.add_trace(go.Bar(name="Cum Realized PnL",
+                         x=df_above.index,
+                         y=df_above["net_realized_pnl"],
+                         marker_color=BULLISH_COLOR,
+                         # hoverdq
+                         showlegend=False))
+    fig.add_trace(go.Bar(name="Cum Realized PnL",
+                         x=df_below.index,
+                         y=df_below["net_realized_pnl"],
+                         marker_color=BEARISH_COLOR,
+                         showlegend=False))
     fig.update_layout(title=dict(
         text='Cummulative PnL',  # Your title text
         x=0.43,

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -228,6 +228,33 @@ def intraday_performance(df: pd.DataFrame):
     return fig
 
 
+def returns_histogram(df: pd.DataFrame):
+    colors = [BULLISH_COLOR if val > 0 else BEARISH_COLOR for val in df["realized_pnl"]]
+    fig = go.Figure()
+    fig.add_trace(go.Histogram(name="Losses",
+                               x=df.loc[df["realized_pnl"] < 0, "realized_pnl"],
+                               marker_color=BEARISH_COLOR))
+    fig.add_trace(go.Histogram(name="Profits",
+                               x=df.loc[df["realized_pnl"] > 0, "realized_pnl"],
+                               marker_color=BULLISH_COLOR))
+    fig.update_layout(title=dict(
+                            text='Returns Histogram',
+                            x=0.5,
+                            # y=0.93,
+                            xanchor="center",
+                            # yanchor="bottom"
+                        ),
+        legend=dict(
+            orientation="h",
+            # entrywidth=70,
+            yanchor="bottom",
+            y=1.02,
+            xanchor="center",
+            x=.48
+        ))
+    return fig
+
+
 style_metric_cards()
 st.subheader("🔫 Data source")
 with st.expander("⬆️ Upload"):

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -83,13 +83,14 @@ def show_strategy_summary(summary_df: pd.DataFrame):
                              column_config={"PnL Over Time": st.column_config.LineChartColumn("PnL Over Time",
                                                                                               y_min=0,
                                                                                               y_max=5000),
-                                            "Examine": st.column_config.CheckboxColumn(required=True)
+                                            "Explore": st.column_config.CheckboxColumn(required=True)
                                             },
-                             use_container_width=True
+                             use_container_width=True,
+                             hide_index=True
                              )
-    selected_rows = summary[summary.Examine]
+    selected_rows = summary[summary.Explore]
     if len(selected_rows) > 0:
-        return selected_rows.drop('Examine', axis=1)
+        return selected_rows.drop('Explore', axis=1)
     else:
         return None
 

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -85,8 +85,10 @@ def show_strategy_summary(summary_df: pd.DataFrame):
                              use_container_width=True
                              )
     selected_rows = summary[summary.Examine]
-    return selected_rows.drop('Examine', axis=1)
-
+    if len(selected_rows) > 0:
+        return selected_rows.drop('Examine', axis=1)
+    else:
+        return None
 
 def summary_chart(df: pd.DataFrame):
     fig = px.bar(df, x="Trading Pair", y="Realized PnL", color="Exchange")
@@ -174,19 +176,13 @@ def intraday_performance(df: pd.DataFrame):
     fig = go.Figure()
     fig.add_trace(go.Barpolar(
         name="Profits",
-        # mode="none",
         r=polar_profits["net_realized_pnl"],
         theta=polar_profits["hour"] * 15,
-        # fill="toself",
-        # fillcolor=BULLISH_COLOR,
         marker_color=BULLISH_COLOR))
     fig.add_trace(go.Barpolar(
         name="Losses",
-        # mode="none",
         r=polar_losses["net_realized_pnl"],
         theta=polar_losses["hour"] * 15,
-        # fill="toself",
-        # fillcolor=BEARISH_COLOR,
         marker_color=BEARISH_COLOR))
     fig.update_layout(
         polar=dict(
@@ -211,7 +207,7 @@ def intraday_performance(df: pd.DataFrame):
             yanchor="bottom"
         ),
         title=dict(
-            text='Intraday Performance',  # Your title text
+            text='Intraday Performance',
             x=0.5,
             y=0.93,
             xanchor="center",
@@ -246,135 +242,139 @@ if selected_db is not None:
         table_tab, chart_tab = st.tabs(["Table", "Chart"])
         with table_tab:
             selection = show_strategy_summary(strategy_data.strategy_summary)
-            selected_exchange = selection["Exchange"].values[0]
-            selected_trading_pair = selection["Trading Pair"].values[0]
+            if selection is not None:
+                selected_exchange = selection["Exchange"].values[0]
+                selected_trading_pair = selection["Trading Pair"].values[0]
         with chart_tab:
             summary_chart = summary_chart(strategy_data.strategy_summary)
             st.plotly_chart(summary_chart, use_container_width=True)
-        st.divider()
-        st.subheader("🔍 Examine Trading Pair")
-        if not any("Error" in value for key, value in selected_db.status.items() if key != "position_executor"):
-            date_array = pd.date_range(start=strategy_data.start_time, end=strategy_data.end_time, periods=60)
-            start_time, end_time = st.select_slider("Select a time range to analyze",
-                                                    options=date_array.tolist(),
-                                                    value=(date_array[0], date_array[-1]))
-
-            single_market = True
-            if single_market:
-                single_market_strategy_data = strategy_data.get_single_market_strategy_data(selected_exchange, selected_trading_pair)
-                strategy_data_filtered = single_market_strategy_data.get_filtered_strategy_data(start_time, end_time)
-                with st.container():
-                    col1, col2, col3, col4, col5, col6, col7, col8 = st.columns(8)
-                    with col1:
-                        st.metric(label=f'Net PNL {strategy_data_filtered.quote_asset}',
-                                  value=round(strategy_data_filtered.net_pnl_quote, 2))
-                    with col2:
-                        st.metric(label='Total Trades', value=strategy_data_filtered.total_orders)
-                    with col3:
-                        st.metric(label='Accuracy',
-                                  value=round(strategy_data_filtered.accuracy, 2))
-                    with col4:
-                        st.metric(label="Profit Factor",
-                                  value=round(strategy_data_filtered.profit_factor, 2))
-                    with col5:
-                        st.metric(label='Duration (Hours)',
-                                  value=round(strategy_data_filtered.duration_seconds / 3600, 2))
-                    with col6:
-                        st.metric(label='Price change',
-                                  value=f"{round(strategy_data_filtered.price_change * 100, 2)} %")
-                    with col7:
-                        buy_trades_amount = round(strategy_data_filtered.total_buy_amount, 2)
-                        avg_buy_price = round(strategy_data_filtered.average_buy_price, 4)
-                        st.metric(label="Total Buy Volume",
-                                  value=round(buy_trades_amount * avg_buy_price, 2))
-                    with col8:
-                        sell_trades_amount = round(strategy_data_filtered.total_sell_amount, 2)
-                        avg_sell_price = round(strategy_data_filtered.average_sell_price, 4)
-                        st.metric(label="Total Sell Volume",
-                                  value=round(sell_trades_amount * avg_sell_price, 2))
-                    st.plotly_chart(pnl_over_time(strategy_data_filtered.trade_fill), use_container_width=True)
-
-                st.subheader("💱 Market activity")
-                if "Error" not in selected_db.status["market_data"] and strategy_data_filtered.market_data is not None:
-                    with st.expander("Market activity", expanded=True):
-                        col1, col2, col3 = st.columns([1, 1, 2])
-                        with col1:
-                            interval = st.selectbox("Candles Interval:", intervals.keys(), index=2)
-                        with col2:
-                            rows_per_page = st.number_input("Candles per Page", value=100, min_value=1, max_value=5000)
-                        with col3:
-                            total_rows = len(
-                                strategy_data_filtered.get_market_data_resampled(interval=f"{intervals[interval]}S"))
-                            total_pages = math.ceil(total_rows / rows_per_page)
-                            if total_pages > 1:
-                                selected_page = st.select_slider("Select page", list(range(total_pages)), total_pages - 1,
-                                                                 key="page_slider")
-                            else:
-                                selected_page = 0
-                            start_idx = selected_page * rows_per_page
-                            end_idx = start_idx + rows_per_page
-                            candles_df = strategy_data_filtered.get_market_data_resampled(
-                                interval=f"{intervals[interval]}S").iloc[
-                                         start_idx:end_idx]
-                            start_time_page = candles_df.index.min()
-                            end_time_page = candles_df.index.max()
-                            page_data_filtered = single_market_strategy_data.get_filtered_strategy_data(start_time_page,
-                                                                                                        end_time_page)
-                        col1, col2 = st.columns([5.5, 1.5])
-                        with col1:
-                            cg = CandlesGraph(candles_df, show_volume=False, extra_rows=2)
-                            cg.add_buy_trades(page_data_filtered.buys)
-                            cg.add_sell_trades(page_data_filtered.sells)
-                            cg.add_pnl(page_data_filtered, row=2)
-                            cg.add_quote_inventory_change(page_data_filtered, row=3)
-                            fig = cg.figure()
-                            st.plotly_chart(fig, use_container_width=True)
-                        with col2:
-                            st.plotly_chart(intraday_performance(page_data_filtered.trade_fill), use_container_width=True)
-                            st.plotly_chart(top_n_trades(page_data_filtered.trade_fill.net_realized_pnl), use_container_width=True)
-                else:
-                    st.warning("Market data is not available so the candles graph is not going to be rendered. "
-                               "Make sure that you are using the latest version of Hummingbot and market data recorder activated.")
-                st.divider()
-                st.subheader("📈 Metrics")
-                with st.container():
-                    col1, col2, col3, col4, col5 = st.columns(5)
-                    with col1:
-                        st.metric(label=f'Trade PNL {strategy_data_filtered.quote_asset}',
-                                  value=round(strategy_data_filtered.trade_pnl_quote, 2))
-                        st.metric(label=f'Fees {strategy_data_filtered.quote_asset}',
-                                  value=round(strategy_data_filtered.cum_fees_in_quote, 2))
-                    with col2:
-                        st.metric(label='Total Buy Trades', value=strategy_data_filtered.total_buy_trades)
-                        st.metric(label='Total Sell Trades', value=strategy_data_filtered.total_sell_trades)
-                    with col3:
-                        st.metric(label='Total Buy Trades Amount',
-                                  value=round(strategy_data_filtered.total_buy_amount, 2))
-                        st.metric(label='Total Sell Trades Amount',
-                                  value=round(strategy_data_filtered.total_sell_amount, 2))
-                    with col4:
-                        st.metric(label='Average Buy Price', value=round(strategy_data_filtered.average_buy_price, 4))
-                        st.metric(label='Average Sell Price', value=round(strategy_data_filtered.average_sell_price, 4))
-                    with col5:
-                        st.metric(label='Inventory change in Base asset',
-                                  value=round(strategy_data_filtered.inventory_change_base_asset, 4))
-                st.divider()
-                st.subheader("Tables")
-                with st.expander("💵 Trades"):
-                    st.write(strategy_data.trade_fill)
-                    download_csv(strategy_data.trade_fill, "trade_fill", "download-trades")
-                with st.expander("📩 Orders"):
-                    st.write(strategy_data.orders)
-                    download_csv(strategy_data.orders, "orders", "download-orders")
-                with st.expander("⌕ Order Status"):
-                    st.write(strategy_data.order_status)
-                    download_csv(strategy_data.order_status, "order_status", "download-order-status")
+        if selection is None:
+            st.info("Choose a trading pair and start analyzing!")
         else:
-            st.warning("We are encountering challenges in maintaining continuous analysis of this database.")
-            with st.expander("DB Status"):
-                status_df = pd.DataFrame([selected_db.status]).transpose().reset_index()
-                status_df.columns = ["Attribute", "Value"]
-                st.table(status_df)
+            st.divider()
+            st.subheader("🔍 Examine Trading Pair")
+            if not any("Error" in value for key, value in selected_db.status.items() if key != "position_executor"):
+                date_array = pd.date_range(start=strategy_data.start_time, end=strategy_data.end_time, periods=60)
+                start_time, end_time = st.select_slider("Select a time range to analyze",
+                                                        options=date_array.tolist(),
+                                                        value=(date_array[0], date_array[-1]))
+
+                single_market = True
+                if single_market:
+                    single_market_strategy_data = strategy_data.get_single_market_strategy_data(selected_exchange, selected_trading_pair)
+                    strategy_data_filtered = single_market_strategy_data.get_filtered_strategy_data(start_time, end_time)
+                    with st.container():
+                        col1, col2, col3, col4, col5, col6, col7, col8 = st.columns(8)
+                        with col1:
+                            st.metric(label=f'Net PNL {strategy_data_filtered.quote_asset}',
+                                      value=round(strategy_data_filtered.net_pnl_quote, 2))
+                        with col2:
+                            st.metric(label='Total Trades', value=strategy_data_filtered.total_orders)
+                        with col3:
+                            st.metric(label='Accuracy',
+                                      value=round(strategy_data_filtered.accuracy, 2))
+                        with col4:
+                            st.metric(label="Profit Factor",
+                                      value=round(strategy_data_filtered.profit_factor, 2))
+                        with col5:
+                            st.metric(label='Duration (Hours)',
+                                      value=round(strategy_data_filtered.duration_seconds / 3600, 2))
+                        with col6:
+                            st.metric(label='Price change',
+                                      value=f"{round(strategy_data_filtered.price_change * 100, 2)} %")
+                        with col7:
+                            buy_trades_amount = round(strategy_data_filtered.total_buy_amount, 2)
+                            avg_buy_price = round(strategy_data_filtered.average_buy_price, 4)
+                            st.metric(label="Total Buy Volume",
+                                      value=round(buy_trades_amount * avg_buy_price, 2))
+                        with col8:
+                            sell_trades_amount = round(strategy_data_filtered.total_sell_amount, 2)
+                            avg_sell_price = round(strategy_data_filtered.average_sell_price, 4)
+                            st.metric(label="Total Sell Volume",
+                                      value=round(sell_trades_amount * avg_sell_price, 2))
+                        st.plotly_chart(pnl_over_time(strategy_data_filtered.trade_fill), use_container_width=True)
+
+                    st.subheader("💱 Market activity")
+                    if "Error" not in selected_db.status["market_data"] and strategy_data_filtered.market_data is not None:
+                        with st.expander("Market activity", expanded=True):
+                            col1, col2, col3 = st.columns([1, 1, 2])
+                            with col1:
+                                interval = st.selectbox("Candles Interval:", intervals.keys(), index=2)
+                            with col2:
+                                rows_per_page = st.number_input("Candles per Page", value=100, min_value=1, max_value=5000)
+                            with col3:
+                                total_rows = len(
+                                    strategy_data_filtered.get_market_data_resampled(interval=f"{intervals[interval]}S"))
+                                total_pages = math.ceil(total_rows / rows_per_page)
+                                if total_pages > 1:
+                                    selected_page = st.select_slider("Select page", list(range(total_pages)), total_pages - 1,
+                                                                     key="page_slider")
+                                else:
+                                    selected_page = 0
+                                start_idx = selected_page * rows_per_page
+                                end_idx = start_idx + rows_per_page
+                                candles_df = strategy_data_filtered.get_market_data_resampled(
+                                    interval=f"{intervals[interval]}S").iloc[
+                                             start_idx:end_idx]
+                                start_time_page = candles_df.index.min()
+                                end_time_page = candles_df.index.max()
+                                page_data_filtered = single_market_strategy_data.get_filtered_strategy_data(start_time_page,
+                                                                                                            end_time_page)
+                            col1, col2 = st.columns([5.5, 1.5])
+                            with col1:
+                                cg = CandlesGraph(candles_df, show_volume=False, extra_rows=2)
+                                cg.add_buy_trades(page_data_filtered.buys)
+                                cg.add_sell_trades(page_data_filtered.sells)
+                                cg.add_pnl(page_data_filtered, row=2)
+                                cg.add_quote_inventory_change(page_data_filtered, row=3)
+                                fig = cg.figure()
+                                st.plotly_chart(fig, use_container_width=True)
+                            with col2:
+                                st.plotly_chart(intraday_performance(page_data_filtered.trade_fill), use_container_width=True)
+                                st.plotly_chart(top_n_trades(page_data_filtered.trade_fill.net_realized_pnl), use_container_width=True)
+                    else:
+                        st.warning("Market data is not available so the candles graph is not going to be rendered. "
+                                   "Make sure that you are using the latest version of Hummingbot and market data recorder activated.")
+                    st.divider()
+                    st.subheader("📈 Metrics")
+                    with st.container():
+                        col1, col2, col3, col4, col5 = st.columns(5)
+                        with col1:
+                            st.metric(label=f'Trade PNL {strategy_data_filtered.quote_asset}',
+                                      value=round(strategy_data_filtered.trade_pnl_quote, 2))
+                            st.metric(label=f'Fees {strategy_data_filtered.quote_asset}',
+                                      value=round(strategy_data_filtered.cum_fees_in_quote, 2))
+                        with col2:
+                            st.metric(label='Total Buy Trades', value=strategy_data_filtered.total_buy_trades)
+                            st.metric(label='Total Sell Trades', value=strategy_data_filtered.total_sell_trades)
+                        with col3:
+                            st.metric(label='Total Buy Trades Amount',
+                                      value=round(strategy_data_filtered.total_buy_amount, 2))
+                            st.metric(label='Total Sell Trades Amount',
+                                      value=round(strategy_data_filtered.total_sell_amount, 2))
+                        with col4:
+                            st.metric(label='Average Buy Price', value=round(strategy_data_filtered.average_buy_price, 4))
+                            st.metric(label='Average Sell Price', value=round(strategy_data_filtered.average_sell_price, 4))
+                        with col5:
+                            st.metric(label='Inventory change in Base asset',
+                                      value=round(strategy_data_filtered.inventory_change_base_asset, 4))
+                    st.divider()
+                    st.subheader("Tables")
+                    with st.expander("💵 Trades"):
+                        st.write(strategy_data.trade_fill)
+                        download_csv(strategy_data.trade_fill, "trade_fill", "download-trades")
+                    with st.expander("📩 Orders"):
+                        st.write(strategy_data.orders)
+                        download_csv(strategy_data.orders, "orders", "download-orders")
+                    with st.expander("⌕ Order Status"):
+                        st.write(strategy_data.order_status)
+                        download_csv(strategy_data.order_status, "order_status", "download-order-status")
+            else:
+                st.warning("We are encountering challenges in maintaining continuous analysis of this database.")
+                with st.expander("DB Status"):
+                    status_df = pd.DataFrame([selected_db.status]).transpose().reset_index()
+                    status_df.columns = ["Attribute", "Value"]
+                    st.table(status_df)
     else:
         st.warning("We were unable to process this SQLite database.")
         with st.expander("DB Status"):

--- a/pages/strategy_performance/app.py
+++ b/pages/strategy_performance/app.py
@@ -390,10 +390,10 @@ if selected_db is not None:
                                     st.plotly_chart(intraday_performance(page_data_filtered.trade_fill), use_container_width=True)
                                     st.plotly_chart(returns_histogram(page_data_filtered.trade_fill), use_container_width=True)
                                 with table_tab:
-                                    st.dataframe(page_data_filtered.trade_fill[["timestamp", "realized_pnl"]].dropna(subset="realized_pnl"),
+                                    st.dataframe(page_data_filtered.trade_fill[["timestamp", "gross_pnl", "trade_fee", "realized_pnl"]].dropna(subset="realized_pnl"),
                                                  use_container_width=True,
                                                  hide_index=True,
-                                                 height=candles_chart.layout.height - 180)
+                                                 height=(min(len(page_data_filtered.trade_fill) * 39, candles_chart.layout.height - 180)))
                         else:
                             st.plotly_chart(candles_graph(candles_df, page_data_filtered), use_container_width=True)
                     else:

--- a/utils/data_manipulation.py
+++ b/utils/data_manipulation.py
@@ -40,7 +40,10 @@ class StrategyData:
                                          "net_realized_pnl_full_series": "PnL Over Time",
                                          "net_realized_pnl_last": "Realized PnL"}, inplace=True)
         strategy_summary.sort_values(["Realized PnL"], ascending=True, inplace=True)
-        strategy_summary["Examine"] = False
+        strategy_summary["Explore"] = False
+        column_names = list(strategy_summary.columns)
+        column_names.insert(0, column_names.pop())
+        strategy_summary = strategy_summary[column_names]
         return strategy_summary
 
     def get_single_market_strategy_data(self, exchange: str, trading_pair: str):

--- a/utils/data_manipulation.py
+++ b/utils/data_manipulation.py
@@ -41,7 +41,6 @@ class StrategyData:
                                          "net_realized_pnl_last": "Realized PnL"}, inplace=True)
         strategy_summary.sort_values(["Realized PnL"], ascending=True, inplace=True)
         strategy_summary["Examine"] = False
-        strategy_summary.loc[0, "Examine"] = True
         return strategy_summary
 
     def get_single_market_strategy_data(self, exchange: str, trading_pair: str):

--- a/utils/data_manipulation.py
+++ b/utils/data_manipulation.py
@@ -249,9 +249,9 @@ class SingleMarketStrategyData:
 
     @property
     def profit_factor(self):
-        total_profit = (self.trade_fill["net_realized_pnl"] >= 0).sum()
-        total_loss = (self.trade_fill["net_realized_pnl"] < 0).sum()
-        return total_profit / total_loss
+        total_profit = self.trade_fill.loc[self.trade_fill["realized_pnl"] >= 0, "realized_pnl"].sum()
+        total_loss = self.trade_fill.loc[self.trade_fill["realized_pnl"] < 0, "realized_pnl"].sum()
+        return total_profit / -total_loss
 
     @property
     def properties_table(self):

--- a/utils/database_manager.py
+++ b/utils/database_manager.py
@@ -158,6 +158,8 @@ class DatabaseManager:
             trade_fills["realized_trade_pnl"] = trade_fills["unrealized_trade_pnl"] + trade_fills["inventory_cost"]
             trade_fills["net_realized_pnl"] = trade_fills["realized_trade_pnl"] - trade_fills["cum_fees_in_quote"]
             trade_fills["realized_pnl"] = trade_fills["net_realized_pnl"].diff()
+            trade_fills["gross_pnl"] = trade_fills["realized_trade_pnl"].diff()
+            trade_fills["trade_fee"] = trade_fills["cum_fees_in_quote"].diff()
             trade_fills["timestamp"] = pd.to_datetime(trade_fills["timestamp"], unit="ms")
             trade_fills["market"] = trade_fills["market"].apply(lambda x: x.lower().replace("_papertrade", ""))
             trade_fills["quote_volume"] = trade_fills["price"] * trade_fills["amount"]

--- a/utils/database_manager.py
+++ b/utils/database_manager.py
@@ -160,6 +160,7 @@ class DatabaseManager:
             trade_fills["realized_pnl"] = trade_fills["net_realized_pnl"].diff()
             trade_fills["timestamp"] = pd.to_datetime(trade_fills["timestamp"], unit="ms")
             trade_fills["market"] = trade_fills["market"].apply(lambda x: x.lower().replace("_papertrade", ""))
+            trade_fills["quote_volume"] = trade_fills["price"] * trade_fills["amount"]
         return trade_fills
 
     def get_order_status(self, order_ids=None, start_date=None, end_date=None):

--- a/utils/graphs.py
+++ b/utils/graphs.py
@@ -152,12 +152,7 @@ class CandlesGraph:
                 x=strategy_data.trade_fill.timestamp,
                 y=strategy_data.trade_fill.inventory_cost,
                 name="Quote Inventory",
-                mode="lines+markers",
-                marker=dict(
-                    size=10,
-                    symbol="arrow",
-                    angleref="previous",
-                ),
+                mode="lines",
                 line=dict(shape="hv"),
             ),
             row=row, col=1
@@ -172,7 +167,6 @@ class CandlesGraph:
                 name="Cum Profit",
                 mode='lines',
                 line=dict(shape="hv", color="rgba(1, 1, 1, 0.5)", dash="dash", width=0.1),
-                # marker=dict(symbol="arrow"),
                 fill="tozeroy",  # Fill to the line below (trade pnl)
                 fillcolor="rgba(0, 255, 0, 0.5)"
             ),


### PR DESCRIPTION
### VERSION 0.10

- Fixes:
    - Download and display full data instead of page data
    - Remove session_state from page. Not necessary yet, makes debugging harder
    - Replace page_data_filtered in CandlesGraph methods

- Features:
    - Add uploading db feature
    - Add position executors to StrategyData class
    - Improve get_trade_fills in order to process multiple exchange, trading pairs and config_file_path combinations
    - Add strategy summary table to StrategyData class
    - Improvements in status property and loading data in database_manager
    - Add properties table and metrics to SingleMarketStrategyData
    - New metrics styling
    - Allow user to explore different strategies (one at time for now)
    - Improve PnL subchart and replace Base Inventory with Quote Inventory
    - Always start from last candlestick page
    - Add panel metrics/charts
        - Add top/worst realized PnL chart (unused for now)
        - Add intraday performance chart
        - Add returns histogram
        - Add trades table
    - Improve error handling
