### PR TITLE
feat / add helper script for authentication

### DIFF
--- a/helpers/add_authemail.py
+++ b/helpers/add_authemail.py
@@ -10,17 +10,16 @@ if len(new_email) == 0:
     print("\nNo email added, please try again!\n")
     exit()
 
-
 # load the YAML file 
 yaml_file = "../credentials.yml" 
 with open(yaml_file, "r") as file:
     data = yaml.safe_load(file)
 
-# update the admin password on credentials.yml
+# append the email address to credentials.yml
 data["preauthorized"]["emails"].append(new_email)
 
 # write the updated data back to the file
 with open(yaml_file, "w") as file:
     yaml.dump(data, file, Dumper=yaml.RoundTripDumper)
 
-print("Email has been added")
+print("Email has been successfully added!")

--- a/helpers/add_authemail.py
+++ b/helpers/add_authemail.py
@@ -1,0 +1,26 @@
+import streamlit_authenticator as stauth
+import ruamel.yaml as yaml
+import os
+
+# enter email address
+new_email = input("Enter dashboard email >> ") 
+
+# if user enter no email address, exit setup!
+if len(new_email) == 0:
+    print("\nNo email added, please try again!\n")
+    exit()
+
+
+# load the YAML file 
+yaml_file = "../credentials.yml" 
+with open(yaml_file, "r") as file:
+    data = yaml.safe_load(file)
+
+# update the admin password on credentials.yml
+data["preauthorized"]["emails"].append(new_email)
+
+# write the updated data back to the file
+with open(yaml_file, "w") as file:
+    yaml.dump(data, file, Dumper=yaml.RoundTripDumper)
+
+print("Email has been added")

--- a/helpers/edit_authadmin_password.py
+++ b/helpers/edit_authadmin_password.py
@@ -1,0 +1,24 @@
+import streamlit_authenticator as stauth
+import ruamel.yaml as yaml
+import os
+
+# enter admin password or use default t3st01
+new_password = input("Enter dashboard password >> ") 
+new_password = new_password or "t3st01" 
+
+# extract the hash password from the List
+hash_password = stauth.Hasher([new_password]).generate()[0] 
+
+# load the YAML file 
+yaml_file = "../credentials.yml" 
+with open(yaml_file, "r") as file:
+    data = yaml.safe_load(file)
+
+# update the admin password on credentials.yml
+data["credentials"]["usernames"]["admin"]["password"] = hash_password 
+
+# write the updated data back to the file
+with open(yaml_file, "w") as file:
+    yaml.dump(data, file, Dumper=yaml.RoundTripDumper)
+
+print("Admin password has been updated! ")


### PR DESCRIPTION
Add helper folder with scripts for users to easily update credentials.yml

add_authemail.py
- prompt user to enter email address
- if user add none, exit the script 
- adds the email address to credentials.yml

edit_authadmin_password.py
- prompt user to enter admin password 
- If user addnone, uses default `t3st01`
- update admin password on credentials.yml

---

How to use:
1. conda activate dashboard
2. python ./helper/add_authemail.py or ./helper/edit_authadmin_password.py
