### PR TITLE
Update INSTALLATION.md on hash generate

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -47,8 +47,8 @@ streamlit run main.py
 
     ```
     import streamlit_authenticator as st_auth
-    hashed_password = st_auth.hasher_generate("YOUR_PLAIN_TEXT_PASSWORD")
-
+    hashed_password = st_auth.Hasher("YOUR_PLAIN_TEXT_PASSWORD").generate()[0]
+    print(hashed_password)
     ```
 
 3 - Edit the Credentials YAML File


### PR DESCRIPTION
Update the https://github.com/hummingbot/dashboard/blob/main/INSTALLATION.md#method-1-using-hasher_generate to:
```
import streamlit_authenticator as st_auth
hashed_password = st_auth.Hasher("YOUR_PLAIN_TEXT_PASSWORD").generate()[0]
print(hashed_password)
```
steamlit_authenticator seem to have updated and `hasher_generate` is not supported anymore
![image](https://github.com/hummingbot/dashboard/assets/73840223/2d35cc48-4264-4433-b1a6-20a576b46563)
![image](https://github.com/hummingbot/dashboard/assets/73840223/01a331eb-a004-425e-a52d-f0de025b3c60)
