### PR TITLE
fix/streamlit-auth-issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,17 +110,17 @@ elif st.session_state["authentication_status"]:
     dump_dict_to_yaml(config, "credentials.yml")
     with st.sidebar:
         st.write(f'Welcome {st.session_state["name"]}!')
-    st.session_state.authenticator.logout('Logout', 'sidebar')
+    st.session_state.authenticator.logout(location='sidebar')  # Updated logout call
     main_page()
 else:
     show_pages([
         Page("main.py", "Hummingbot Dashboard", "📊"),
     ])
-    name, authentication_status, username = st.session_state.authenticator.login('Login', 'main')
+    name, authentication_status, username = st.session_state.authenticator.login(location='main')  # Updated login call
     if st.session_state["authentication_status"] == False:
         st.error('Username/password is incorrect')
     elif st.session_state["authentication_status"] == None:
         st.warning('Please enter your username and password')
     st.write("---")
     st.write("If you are pre-authorized, you can login with your pre-authorized mail!")
-    st.session_state.authenticator.register_user('Register', 'main')
+    st.session_state.authenticator.register_user(location='main')  # Updated register user call


### PR DESCRIPTION
- fixes error below because of update to streamlit-authenticator library


"DeprecationError: Likely deprecation error, the 'form_name' parameter has been replaced with the 'fields' parameter. For further information please refer to https://github.com/mkhorasani/Streamlit-Authenticator?tab=readme-ov-file#2-creating-a-login-widget

Traceback:
File "/home/vago/miniconda3/envs/dashboard/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 535, in _run_script
    exec(code, module._dict_)
File "/home/vago/hummingBot/dashboard/main.py", line 119, in <module>
    name, authentication_status, username = st.session_state.authenticator.login('Login', 'main')
File "/home/vago/miniconda3/envs/dashboard/lib/python3.10/site-packages/streamlit_authenticator/authenticate.py", line 241, in login
    raise DeprecationError("""Likely deprecation error, the 'form_name' parameter has been replaced"