### PR TITLE
keep compatibility version

### DIFF
--- a/environment_conda.yml
+++ b/environment_conda.yml
@@ -8,7 +8,7 @@ dependencies:
   - pydantic=1.9.*
   - pip
   - pip:
-      - hummingbot
+      - hummingbot==20240129
       - streamlit
       - watchdog
       - plotly


### PR DESCRIPTION
The compatibility with the code is broken with the new version of hummingbot (version [20240429](https://pypi.org/project/hummingbot/20240429/))

```python
from hummingbot.smart_components.strategy_frameworks.directional_trading import DirectionalTradingControllerBase, DirectionalTradingControllerConfigBase
```

In detail the smart_components imported from hummingbot in the os_utils.py file does not exists anymore.

![image](https://github.com/hummingbot/dashboard/assets/49456524/a6474be8-4f6c-453d-8437-9b217b090180)

In the meantime, while the code is being reviewed to use the new version, I forced to install the previous version of hummingbot. 
