### PR TITLE
(doc) Update installation instructions to reflect renamings in makefile

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,7 +21,7 @@ cd dashboard
 
 3 - Create `conda` environment and install dependencies
 ```bash
-make env_create
+make install
 ```
 
 4 - Activate the isolated 'conda' environment
@@ -116,8 +116,8 @@ streamlit run main.py
 
 To update the `dashboard` environment for changes to dependencies defined in `environment.yml`, remove the environment and re-create it:
 ```
-make env_remove
-make env_create
+make uninstall
+make install
 ```
 
 To updated the `dashboard` source for latest version, run:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently, Dashboard should be installed from source via the process below. In t
 
 3. **Create Conda Environment and Install Dependencies**:
     ```bash
-    make env_create
+    make install
     ```
 
 4. **Activate the Isolated 'conda' Environment**:


### PR DESCRIPTION
[This commit](https://github.com/hummingbot/dashboard/commit/24617500d15619445386ce1b443675e7a239883f#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9) from last month renamed the Makefile's "env_create" and "env_remove" to "install" and "uninstall". I am reflecting these changes to the instructions in README.md and INSTALLATION.md