### PR TITLE
Added trailing stop to backtest visualizer

### DIFF
--- a/frontend/visualization/backtesting_metrics.py
+++ b/frontend/visualization/backtesting_metrics.py
@@ -58,6 +58,7 @@ def render_close_types(summary_results):
     st.write("#### Close Types")
     close_types = summary_results.get('close_types', {})
     st.metric(label="TAKE PROFIT", value=f"{close_types.get('TAKE_PROFIT', 0)}")
+    st.metric(label="TRAILING STOP", value=f"{close_types.get('TRAILING_STOP', 0)}")
     st.metric(label="STOP LOSS", value=f"{close_types.get('STOP_LOSS', 0)}")
     st.metric(label="TIME LIMIT", value=f"{close_types.get('TIME_LIMIT', 0)}")
     st.metric(label="EARLY STOP", value=f"{close_types.get('EARLY_STOP', 0)}")


### PR DESCRIPTION
Allows visualizing the trailing stop as introduced by this PR: https://github.com/hummingbot/hummingbot/pull/7084

Both PRs need to be accepted in order for this to work, and hummingbot-deploy's Backend API needs to be compiled with the hummingbot project with this PR. 

See screenshot for change:

![image](https://github.com/hummingbot/dashboard/assets/1212814/f5ef28fa-27f9-438a-8cd4-52eeb1e05007)
