### PR TITLE
(feat) add support for Bitget_perpetual candles (download candles)

### DIFF
--- a/frontend/pages/data/download_candles/app.py
+++ b/frontend/pages/data/download_candles/app.py
@@ -13,7 +13,8 @@ backend_api_client = get_backend_api_client()
 c1, c2, c3, c4 = st.columns([2, 2, 2, 0.5])
 with c1:
     connector = st.selectbox("Exchange",
-                             ["binance_perpetual", "binance", "gate_io", "gate_io_perpetual", "kucoin", "ascend_ex"],
+                             ["binance_perpetual", "binance", "gate_io", "gate_io_perpetual", "kucoin", "ascend_ex",
+                              "bitget_perpetual"],
                              index=0)
     trading_pair = st.text_input("Trading Pair", value="BTC-USDT")
 with c2:


### PR DESCRIPTION
**Before submitting this PR, please make sure**:

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved title ("feat/", "fix/", "docs/", "refactor/")

**A description of the changes proposed in the pull request**:
Adding support for download candles to "bitget_perpetual" exchange connector. This feature needs the following pull request performed:
[](https://github.com/hummingbot/hummingbot/pull/7305)


**Tests performed by the developer**:
Downloaded in various intervals (1m, 5m, 1h, 1d) and dates (2023 and 2024) for BTC-USDT and ETH-USDT symbol pairs.

Timestamp results were validated with "binance_perpetual" (under the same configuration).

Data where compared with real data from Biget website. In the  case of BTC-USDT:
[](https://www.bitget.com/es/futures/usdt/BTCUSDT)


**Tips for QA testing**:
I am living in GMT+1, so the data displayed on the chart is 1 hour behind.

