### PR TITLE
fix(): Set plotly version to 5.24.1

### DIFF
--- a/environment_conda.yml
+++ b/environment_conda.yml
@@ -12,7 +12,7 @@ dependencies:
       - streamlit==1.33.0
       - watchdog
       - python-dotenv
-      - plotly
+      - plotly==5.24.1
       - pycoingecko
       - glom
       - defillama


### PR DESCRIPTION
### Issue
The newest `plotly==6.0.1` version doesn't seem to go well with `streamlit==1.33.0` and breaks all the charts using candlesticks (maybe even others).

### What was done
Reduced/locked the `plotly` version from `latest` to `5.24.1` (latest previous major) 

### Prove
Before the fix:
![Screenshot from 2025-03-22 16-54-16](https://github.com/user-attachments/assets/32d6928c-99e6-4501-b23b-efeef0ed48dd)

After the fix:
![Screenshot from 2025-03-22 16-51-48](https://github.com/user-attachments/assets/6840f989-3206-4508-8eb3-a1683a0e4159)
